### PR TITLE
stack lts-18 and GH CI action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,31 @@
+name: build
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ghc: ['8.10', '8.8', '8.6']
+    name: Haskell GHC ${{ matrix.ghc }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: haskell/actions/setup@v1
+        with:
+          ghc-version: ${{ matrix.ghc }}
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cabal
+            dist-newstyle
+          key: ${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('**/*.cabal','**/cabal.project') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.ghc }}-
+            ${{ runner.os }}-
+      - run: cabal update
+      - run: cabal build
+      - run: cabal test
+      - run: cabal bench

--- a/hid-examples.cabal
+++ b/hid-examples.cabal
@@ -498,7 +498,7 @@ executable elevator
   build-depends:
       base >=4.12 && <4.15
     , dec >=0.0.3 && <0.1
-    , fin >=0.1 && <0.2
+    , fin >=0.1 && <0.3
     , mtl >=2.0 && <2.3
     , singletons >=2.5 && <2.8
   default-language: Haskell2010

--- a/package.yaml
+++ b/package.yaml
@@ -523,7 +523,7 @@ executables:
           - Elevator.Safe.Operations
           - Elevator.Safe.Moves
         dependencies:
-          - fin >= 0.1 && < 0.2
+          - fin >= 0.1 && < 0.3
           - dec >= 0.0.3 && < 0.1
           - singletons >= 2.5 && < 2.8
           - mtl >=2.0 && <2.3

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-17.4
+resolver: lts-18.21
 
 packages:
 - .
@@ -10,31 +10,24 @@ flags:
 #    with-pg: True
 
 extra-deps:
-  - streaming-utils-0.2.0.0
-  - json-stream-0.4.2.4
-  - HDBC-postgresql-2.3.2.7
-  - hasql-th-0.4.0.8
-  - headed-megaparsec-0.2
-  - selective-0.4.1
-  - template-haskell-compat-v0208-0.1.5
-  - hasql-transaction-1.0.0.1
-  - opaleye-0.7.0.0
-  - product-profunctors-0.11.0.0
-  - streaming-bytestring-0.1.7
-  - random-1.2.0
-  - splitmix-0.1.0.3
+  - Chart-diagrams-1.9.3
+  - HDBC-postgresql-2.4.0.0
+  - SVGFonts-1.7.0.1
+  - active-0.2.0.15
   - blaze-colonnade-1.2.2.1
   - colonnade-1.2.0.2
-  - Chart-diagrams-1.9.3
-  - SVGFonts-1.7.0.1
-  - diagrams-core-1.4.2
-  - diagrams-lib-1.4.3
+  - diagrams-core-1.5.0
+  - diagrams-lib-1.4.5.1
   - diagrams-postscript-1.5
-  - diagrams-svg-1.4.3
-  - svg-builder-0.1.1
-  - active-0.2.0.14
-  - dual-tree-0.2.2.1
-  - monoid-extras-0.5.1
+  - diagrams-svg-1.4.3.1
+  - dual-tree-0.2.3.0
+  - fast-builder-0.1.3.0
+  - hasql-th-0.4.0.10
+  - headed-megaparsec-0.2.0.2
+  - json-stream-0.4.2.4
+  - monoid-extras-0.6.1
+  - postgresql-syntax-0.4
   - statestack-0.3
-  - fast-builder-0.1.2.1
-  - postgresql-syntax-0.3.0.3
+  - streaming-utils-0.2.1.0
+  - svg-builder-0.1.1
+  - template-haskell-compat-v0208-0.1.5


### PR DESCRIPTION
This updates stack.yaml to lts-18 (sorting the extra-deps).
Also bump `fin` to allow 0.2.
And add a GH Ci to test building.

BTW I would suggest also to drop package.yaml, which is deprecated by recent stack.
It doesn't lead to good workflow.  I can add that change too if you don't mind.