### PR TITLE
stack: use final lts-18 snapshot

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-18.21
+resolver: lts-18.28
 
 packages:
 - .


### PR DESCRIPTION
This just updates stack.yaml from lts-18.18 to lts-18.28.
It should be a safe small minor change, updating to the final lts-18 minor snapshot.

I checked locally on Linux that `stack build`, `stack test`, and `stack bench` all complete.
